### PR TITLE
Add grunt precommit task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,4 +6,39 @@ module.exports = function (grunt) {
 	// load grunt config
 	require('load-grunt-config')(grunt);
 
+	// PHPUnit test task.
+	grunt.registerMultiTask( 'phpcs', 'Runs PHPCS tests.', function() {
+		grunt.util.spawn( {
+			cmd:  this.data.cmd,
+			args: this.data.args,
+			opts: { stdio: 'inherit' }
+		}, this.async() );
+	} );
+
+	// PHPUnit test task.
+	grunt.registerMultiTask( 'phpcpd', 'Runs PHPCPD tests.', function() {
+		grunt.util.spawn( {
+			cmd:  this.data.cmd,
+			args: this.data.args,
+			opts: { stdio: 'inherit' }
+		}, this.async() );
+	} );
+
+	// PHPUnit test task.
+	grunt.registerMultiTask( 'phpmd', 'Runs PHPMD tests.', function() {
+		grunt.util.spawn( {
+			cmd:  this.data.cmd,
+			args: this.data.args,
+			opts: { stdio: 'inherit' }
+		}, this.async() );
+	} );
+
+	// PHPUnit test task.
+	grunt.registerMultiTask( 'phpunit', 'Runs PHPUnit tests.', function() {
+		grunt.util.spawn( {
+			cmd:  this.data.cmd,
+			args: this.data.args,
+			opts: { stdio: 'inherit' }
+		}, this.async() );
+	} );
 };

--- a/grunt/aliases.yaml
+++ b/grunt/aliases.yaml
@@ -12,6 +12,13 @@ build:
 - 'copy:main'
 - 'compress' # Can comment this out for WordPress.org plugins
 
+# Pre commit task
+precommit:
+- 'phpcs'
+- 'phpcpd'
+- 'phpmd'
+- 'phpunit'
+
 # Prepare a WordPress.org release
 release:prepare:
 - 'build'

--- a/grunt/checktextdomain.js
+++ b/grunt/checktextdomain.js
@@ -1,7 +1,7 @@
 module.exports = {
 	dist: {
 		options: {
-			text_domain   : 'wp-api-oembed',
+			text_domain   : 'oembed-api',
 			report_missing: true,
 			correct_domain: true,
 			keywords      : [

--- a/grunt/phpcpd.js
+++ b/grunt/phpcpd.js
@@ -1,0 +1,6 @@
+module.exports = {
+	default: {
+		cmd: 'phpcpd',
+		args: [ '-n', 'classes' ]
+	}
+}

--- a/grunt/phpcs.js
+++ b/grunt/phpcs.js
@@ -1,0 +1,6 @@
+module.exports = {
+	default: {
+		cmd: 'phpcs',
+		args: [ '-n', '--report=emacs', '--standard=phpcs.ruleset.xml', 'classes' ]
+	}
+}

--- a/grunt/phpmd.js
+++ b/grunt/phpmd.js
@@ -1,0 +1,7 @@
+module.exports = {
+	default: {
+		cmd: 'phpmd',
+		args: [ 'classes', 'text', 'cleancode,codesize,naming,unusedcode' ]
+	}
+}
+

--- a/grunt/phpunit.js
+++ b/grunt/phpunit.js
@@ -1,3 +1,6 @@
 module.exports = {
-	default: {}
+	default: {
+		cmd: 'phpunit',
+		args: [ '-c', 'phpunit.xml' ]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-contrib-compress": "~0.13.0",
     "grunt-contrib-copy": "~0.7.0",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-phpunit": "~0.3.6",
+    "grunt-exec": "~0.4.6",
     "grunt-text-replace": "~0.4.0",
     "grunt-wp-i18n": "~0.5.1",
     "grunt-wp-deploy": "~1.0.3",


### PR DESCRIPTION
* Replaces NPM package `grunt-phpunit` with `grunt-exec`
* Adds Grunt tasks `phpcs`, `phpcpd`, and `phpmd` using parameters copied from `.travis.yml`
* Adds Grunt task `precommit` that runs, `phpunit`, `phpcs`, `phpcpd`, and `phpmd` tasks
* Updates `checktextdomain` task with correct (plugin slug) text domain `oembed-api`