### PR TITLE
Add XML response format

### DIFF
--- a/classes/endpoint.php
+++ b/classes/endpoint.php
@@ -182,7 +182,7 @@ class WP_API_oEmbed_Endppoint {
 		}
 		echo '</oembed>';
 
-		return true;
+		return $served = true;
 	}
 
 	/**
@@ -196,14 +196,18 @@ class WP_API_oEmbed_Endppoint {
 			foreach ( $value as $k => $v ) {
 				$this->xml_wrap( $k, $v );
 			}
+
+			return;
 		} else if ( is_array( $value ) ) {
 			echo "<$key>";
 			foreach ( $value as $k => $v ) {
 				$this->xml_wrap( $k, $v );
 			}
 			echo "</$key>";
-		} else {
-			echo "<$key>" . esc_html( $value ) . "</$key>";
+
+			return;
 		}
+
+		echo "<$key>" . esc_html( $value ) . "</$key>";
 	}
 }

--- a/classes/endpoint.php
+++ b/classes/endpoint.php
@@ -171,7 +171,9 @@ class WP_API_oEmbed_Endppoint {
 			return $served;
 		}
 
-		$server->send_header( 'Content-Type', 'text/xml; charset=' . get_option( 'blog_charset' ) );
+		if ( ! headers_sent() ) {
+			$server->send_header( 'Content-Type', 'text/xml; charset=' . get_option( 'blog_charset' ) );
+		}
 
 		// Embed links inside the request.
 		$result = $server->response_to_data( $result, false );

--- a/classes/endpoint.php
+++ b/classes/endpoint.php
@@ -53,6 +53,10 @@ class WP_API_oEmbed_Endppoint {
 			return new WP_Error( 'rest_oembed_invalid_url', __( 'Invalid URL.', 'oembed-api' ), array( 'status' => 404 ) );
 		}
 
+		if ( ! in_array( $request['format'], array( 'json', 'xml' ) ) ) {
+			return new WP_Error( 'rest_oembed_invalid_format', __( 'Invalid format.', 'oembed-api' ), array( 'status' => 501 ) );
+		}
+
 		/**
 		 * Current post object.
 		 *

--- a/classes/frontend.php
+++ b/classes/frontend.php
@@ -38,6 +38,7 @@ class WP_API_oEmbed_Frontend {
 
 		if ( is_singular() ) {
 			$output .= '<link rel="alternate" type="application/json+oembed" href="' . esc_url( rest_url( 'wp/v2/oembed?url=' . get_permalink() ) ) . '" />' . "\n";
+			$output .= '<link rel="alternate" type="text/xml+oembed" href="' . esc_url( rest_url( 'wp/v2/oembed?url=' . get_permalink() . '&format=xml' ) ) . '" />' . "\n";
 		}
 
 		$output = apply_filters( 'rest_oembed_discovery_links', $output );
@@ -51,8 +52,8 @@ class WP_API_oEmbed_Frontend {
 	 * @param WP_Post $post The current post object.
 	 */
 	public function rest_oembed_output( $post ) {
-		$post_content = strip_tags( $post->post_content );
-		$words        = str_word_count( $post_content );
+		$post_content   = strip_tags( $post->post_content );
+		$words          = str_word_count( $post_content );
 		$oembed_content = $post_content;
 
 		if ( count( $words ) > 35 ) {

--- a/tests/test-frontend.php
+++ b/tests/test-frontend.php
@@ -54,6 +54,7 @@ class WP_API_oEmbed_Test_Frontend extends WP_API_oEmbed_TestCase {
 		$actual = ob_get_clean();
 
 		$expected = '<link rel="alternate" type="application/json+oembed" href="' . esc_url( rest_url( 'wp/v2/oembed?url=' . get_permalink( $post_id ) ) ) . '" />' . "\n";
+		$expected .= '<link rel="alternate" type="text/xml+oembed" href="' . esc_url( rest_url( 'wp/v2/oembed?url=' . get_permalink() . '&format=xml' ) ) . '" />' . "\n";
 
 		$this->assertEquals( $expected, $actual );
 	}


### PR DESCRIPTION
I now used one of the available filters to support XML output as this is considered good practice by the oEmbed spec.

One thing I currently don't like is how we treat errors. We just return error objects, and especially with the XML response this doesn't feel right. -> something for a new issue

This would fix #11