### PR TITLE
fix attachment embed URLs

### DIFF
--- a/wp-api-oembed.php
+++ b/wp-api-oembed.php
@@ -91,7 +91,7 @@ function get_post_embed_url( $post = null ) {
 
 	$embed_url = add_query_arg( array( 'embed' => 'true' ), get_permalink( $post ) );
 
-	if ( get_option( 'permalink_structure' ) ) {
+	if ( get_option( 'permalink_structure' ) && $post->post_type !== 'attachment' ) {
 		$embed_url = trailingslashit( get_permalink( $post ) ) . user_trailingslashit( 'embed' );
 	}
 


### PR DESCRIPTION
There are no rewrite rules for attachment URLs, so we can’t use
`/embed/` and have to use the query string instead:
`http://example.com/?attachment_id=1337&embed=true`