### PR TITLE
Remove `security` attributes in IE 10 and above

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -44,6 +44,7 @@ $post_content = wp_trim_words( $post_content, $num_words, ' <span class="wp-embe
 <html>
 <head>
 	<title><?php esc_html_e( $post->post_title, 'oembed-api' ); ?></title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,700"/>
 	<link rel="stylesheet" href="https://s.w.org/wp-includes/css/dashicons.css"/>
 	<style type="text/css">

--- a/includes/template.php
+++ b/includes/template.php
@@ -261,18 +261,18 @@ $post_content = wp_trim_words( $post_content, $num_words, ' <span class="wp-embe
 			var hash, secret, share_dialog, embed, resize_limiter;
 
 			window.onload = function () {
-				share_dialog = document.getElementsByClassName( 'wp-embed-share-dialog' )[ 0 ];
+				share_dialog = document.querySelectorAll( '.wp-embed-share-dialog' )[ 0 ];
 
-				document.getElementsByClassName( 'wp-embed-share-input' )[ 0 ].onclick = function ( e ) {
+				document.querySelectorAll( '.wp-embed-share-input' )[ 0 ].onclick = function ( e ) {
 					e.target.select();
 				};
 
-				document.getElementsByClassName( 'wp-embed-share-dialog-open' )[ 0 ].onclick = function ( e ) {
+				document.querySelectorAll( '.wp-embed-share-dialog-open' )[ 0 ].onclick = function ( e ) {
 					share_dialog.className = share_dialog.className.replace( 'hidden', '' );
 					e.preventDefault();
 				};
 
-				document.getElementsByClassName( 'wp-embed-share-dialog-close' )[ 0 ].onclick = function ( e ) {
+				document.querySelectorAll( '.wp-embed-share-dialog-close' )[ 0 ].onclick = function ( e ) {
 					share_dialog.className += ' hidden';
 					e.preventDefault();
 				};
@@ -284,7 +284,7 @@ $post_content = wp_trim_words( $post_content, $num_words, ' <span class="wp-embe
 				hash = window.location.hash;
 				secret = hash.replace( /.*secret=([\d\w]{10}).*/, '$1' );
 
-				embed = document.getElementsByClassName( 'wp-embed' )[ 0 ];
+				embed = document.querySelectorAll( '.wp-embed' )[ 0 ];
 
 				/**
 				 * Send this document's height to the parent (embedding) site.

--- a/includes/template.php
+++ b/includes/template.php
@@ -261,18 +261,18 @@ $post_content = wp_trim_words( $post_content, $num_words, ' <span class="wp-embe
 			var hash, secret, share_dialog, embed, resize_limiter;
 
 			window.onload = function () {
-				share_dialog = document.querySelectorAll( '.wp-embed-share-dialog' )[ 0 ];
+				share_dialog = document.getElementsByClassName( 'wp-embed-share-dialog' )[ 0 ];
 
-				document.querySelectorAll( '.wp-embed-share-input' )[ 0 ].onclick = function ( e ) {
+				document.getElementsByClassName( 'wp-embed-share-input' )[ 0 ].onclick = function ( e ) {
 					e.target.select();
 				};
 
-				document.querySelectorAll( '.wp-embed-share-dialog-open' )[ 0 ].onclick = function ( e ) {
+				document.getElementsByClassName( 'wp-embed-share-dialog-open' )[ 0 ].onclick = function ( e ) {
 					share_dialog.className = share_dialog.className.replace( 'hidden', '' );
 					e.preventDefault();
 				};
 
-				document.querySelectorAll( '.wp-embed-share-dialog-close' )[ 0 ].onclick = function ( e ) {
+				document.getElementsByClassName( 'wp-embed-share-dialog-close' )[ 0 ].onclick = function ( e ) {
 					share_dialog.className += ' hidden';
 					e.preventDefault();
 				};
@@ -284,7 +284,7 @@ $post_content = wp_trim_words( $post_content, $num_words, ' <span class="wp-embe
 				hash = window.location.hash;
 				secret = hash.replace( /.*secret=([\d\w]{10}).*/, '$1' );
 
-				embed = document.querySelectorAll( '.wp-embed' )[ 0 ];
+				embed = document.getElementsByClassName( 'wp-embed' )[ 0 ];
 
 				/**
 				 * Send this document's height to the parent (embedding) site.

--- a/scripts/frontend.js
+++ b/scripts/frontend.js
@@ -37,3 +37,18 @@ if ( window.addEventListener ) {
 else if ( window.attachEvent ) {
 	window.attachEvent( 'message', receiveEmbedMessage );
 }
+
+window.onload = function () {
+	var ieVersion = new Function( "/*@cc_on return @_jscript_version; @*/" )();
+
+	// Remove security attribute from iframes in IE10 and IE11.
+	if ( 10 === ieVersion || navigator.userAgent.indexOf("Trident/7.0") > 0 ) {
+		var iframes = document.getElementsByTagName( 'iframe' ), iframeClone;
+		for ( var i = 0; i < iframes.length; i++ ) {
+			iframeClone = iframes[ i ].cloneNode( true );
+			iframeClone.removeAttribute( 'security' );
+			iframes[ i ].parentNode.insertBefore( iframeClone, iframes[ i ].nextSibling );
+			iframes[ i ].parentNode.removeChild( iframes[ i ] );
+		}
+	}
+}

--- a/scripts/frontend.js
+++ b/scripts/frontend.js
@@ -39,10 +39,11 @@ else if ( window.attachEvent ) {
 }
 
 window.onload = function () {
-	var ieVersion = new Function( "/*@cc_on return @_jscript_version; @*/" )();
+	var isIE10 = 10 === new Function( "/*@cc_on return @_jscript_version; @*/" )(),
+		isIE11 = !! navigator.userAgent.match( /Trident.*rv\:11\./ );
 
 	// Remove security attribute from iframes in IE10 and IE11.
-	if ( 10 === ieVersion || navigator.userAgent.indexOf("Trident/7.0") > 0 ) {
+	if ( isIE10 || isIE11 ) {
 		var iframes = document.getElementsByTagName( 'iframe' ), iframeClone;
 		for ( var i = 0; i < iframes.length; i++ ) {
 			iframeClone = iframes[ i ].cloneNode( true );


### PR DESCRIPTION
This arised out of #53.

I tested IE8-11 on virtual machines and also real devices to see where we could improve things.

First of all, in older versions of Internet Explorer that don't support the `sandbox` attribute the iframe is not really useful. Normal clicks are working (links open in new tab), but the modal and the icons don't show at all. Not much we can do there.

I added a little snippet to `frontend.js` which removes the `security` attribute from IE10 and IE11. Or better, it _should_. While I successfully tested it on IE10, somehow it won't really trigger in IE11. It would be great if someone else could test that.