### PR TITLE
Make the plugin compatible with WordPress 3.9+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Contributors:      swissspidy, pento, netweb  
 Donate link:         
 Tags:              oembed, api  
-Requires at least: 4.3  
+Requires at least: 3.9  
 Tested up to:      4.3  
 Stable tag:        0.6.0  
 License:           GPLv2 or later  

--- a/includes/class-wp-legacy-oembed-controller.php
+++ b/includes/class-wp-legacy-oembed-controller.php
@@ -106,6 +106,8 @@ class WP_Legacy_oEmbed_Controller {
 	/**
 	 * Print the JSON response.
 	 *
+	 * @SuppressWarnings(PHPMD.ElseExpression)
+	 *
 	 * @param array $data     The oEmbed response data.
 	 * @param array $request  The request arguments.
 	 * @return string The JSON response data.

--- a/includes/class-wp-legacy-oembed-controller.php
+++ b/includes/class-wp-legacy-oembed-controller.php
@@ -115,7 +115,11 @@ class WP_Legacy_oEmbed_Controller {
 			$request['callback'] = false;
 		}
 
-		$result = wp_json_encode( $data );
+		if ( function_exists( 'wp_json_encode' ) ) {
+			$result = wp_json_encode( $data );
+		} else {
+			$result = json_encode( $data );
+		}
 
 		/**
 		 * Filter the JSON response.

--- a/includes/template.php
+++ b/includes/template.php
@@ -400,9 +400,22 @@ setup_postdata( $post );
 
 	<div class="wp-embed-meta">
 		<?php
+		$site_icon_url = admin_url( 'images/w-logo-blue.png' );
+
+		if ( function_exists( 'get_site_icon_url' ) ) {
+			$site_icon_url = get_site_icon_url( 32, $site_icon_url );
+		}
+
+		/**
+		 * Filters the site icon URL for use in the oEmbed template.
+		 *
+		 * @param string $site_icon_url The site icon URL.
+		 */
+		$site_icon_url = apply_filters( 'oembed_site_icon_url', $site_icon_url );
+
 		printf(
 			'<img src="%s" width="32" height="32" alt="" class="wp-embed-site-icon"/>',
-			esc_url( get_site_icon_url( 32, admin_url( 'images/w-logo-blue.png' ) ) )
+			esc_url( $site_icon_url )
 		);
 		?>
 		<div class="wp-embed-site-title">


### PR DESCRIPTION
Somebody might be using an older version of WordPress 😢

Of course we can remove those compatibility checks in a core merge.