### PR TITLE
Wrap anchor tag around site icon too

### DIFF
--- a/includes/template.php
+++ b/includes/template.php
@@ -120,23 +120,19 @@
 			color: #b4b9be;
 		}
 
-		.wp-embed-meta,
-		.wp-embed-social {
-			margin-top: 30px;
-			width: 50%;
-		}
-
 		.wp-embed-meta {
-			float: left;
-			position: relative;
+			display: table;
+			width: 100%;
+			margin-top: 30px;
 		}
 
 		.wp-embed-site-icon {
+			position: absolute;
+			top: 50%;
+			left: 0;
+			transform: translateY(-50%);
 			height: 25px;
 			width: 25px;
-			margin-right: 10px;
-			display: inline-block;
-			vertical-align: middle;
 		}
 
 		.wp-embed-site-title {
@@ -145,18 +141,20 @@
 		}
 
 		.wp-embed-site-title a {
+			position: relative;
 			display: inline-block;
+			padding-left: 35px;
+		}
+
+		.wp-embed-site-title,
+		.wp-embed-social {
+			display: table-cell;
 		}
 
 		.wp-embed-social {
-			float: right;
 			text-align: right;
-		}
-
-		.wp-embed-social::after {
-			content: "";
-			display: table;
-			clear: both;
+			white-space: nowrap;
+			vertical-align: middle;
 		}
 
 		.wp-embed-comments,
@@ -264,18 +262,23 @@
 			font: 400 14px/1.5 'Open Sans', sans-serif;
 		}
 
+		html[dir="rtl"] .wp-embed-site-title a {
+			padding-left: 0;
+			padding-right: 35px;
+		}
+
 		html[dir="rtl"] .wp-embed-site-icon {
 			margin-right: 0;
 			margin-left: 10px;
+			left: auto;
+			right: 0;
 		}
 
 		html[dir="rtl"] .wp-embed-social {
-			float: left;
 			text-align: left;
 		}
 
 		html[dir="rtl"] .wp-embed-meta {
-			float: right;
 		}
 
 		html[dir="rtl"] .wp-embed-share {
@@ -482,31 +485,32 @@
 					);
 					?>
 				</div>
-			</div>
-			<div class="wp-embed-social">
-				<?php if ( get_comments_number() || comments_open() ) : ?>
-					<div class="wp-embed-comments">
-						<a href="<?php comments_link(); ?>" target="_top">
-							<span class="dashicons dashicons-admin-comments"></span>
-							<?php
-							printf(
-								_n(
-									'%s <span class="screen-reader-text">Comment</span>',
-									'%s <span class="screen-reader-text">Comments</span>',
-									get_comments_number(),
-									'oembed-api'
-								),
-								get_comments_number()
-							);
-							?>
-						</a>
+
+				<div class="wp-embed-social">
+					<?php if ( get_comments_number() || comments_open() ) : ?>
+						<div class="wp-embed-comments">
+							<a href="<?php comments_link(); ?>" target="_top">
+								<span class="dashicons dashicons-admin-comments"></span>
+								<?php
+								printf(
+									_n(
+										'%s <span class="screen-reader-text">Comment</span>',
+										'%s <span class="screen-reader-text">Comments</span>',
+										get_comments_number(),
+										'oembed-api'
+									),
+									get_comments_number()
+								);
+								?>
+							</a>
+						</div>
+					<?php endif; ?>
+					<div class="wp-embed-share">
+						<button type="button" class="wp-embed-share-dialog-open"
+						        aria-label="<?php _e( 'Open sharing dialog', 'oembed-api' ); ?>">
+							<span class="dashicons dashicons-share"></span>
+						</button>
 					</div>
-				<?php endif; ?>
-				<div class="wp-embed-share">
-					<button type="button" class="wp-embed-share-dialog-open"
-					        aria-label="<?php _e( 'Open sharing dialog', 'oembed-api' ); ?>">
-						<span class="dashicons dashicons-share"></span>
-					</button>
 				</div>
 			</div>
 			<div class="wp-embed-share-dialog hidden">

--- a/includes/template.php
+++ b/includes/template.php
@@ -134,14 +134,18 @@
 		.wp-embed-site-icon {
 			height: 25px;
 			width: 25px;
+			margin-right: 10px;
+			display: inline-block;
+			vertical-align: middle;
 		}
 
 		.wp-embed-site-title {
-			display: inline;
-			margin-top: 2px;
-			position: absolute;
-			left: 35px;
 			font-weight: bold;
+			line-height: 25px;
+		}
+
+		.wp-embed-site-title a {
+			display: inline-block;
 		}
 
 		.wp-embed-social {
@@ -260,9 +264,9 @@
 			font: 400 14px/1.5 'Open Sans', sans-serif;
 		}
 
-		html[dir="rtl"] .wp-embed-site-title {
-			left: auto;
-			right: 35px;
+		html[dir="rtl"] .wp-embed-site-icon {
+			margin-right: 0;
+			margin-left: 10px;
 		}
 
 		html[dir="rtl"] .wp-embed-social {
@@ -455,27 +459,28 @@
 			<div class="wp-embed-excerpt"><?php the_excerpt_embed(); ?></div>
 
 			<div class="wp-embed-meta">
-				<?php
-				$site_icon_url = admin_url( 'images/w-logo-blue.png' );
-
-				if ( function_exists( 'get_site_icon_url' ) ) {
-					$site_icon_url = get_site_icon_url( 32, $site_icon_url );
-				}
-
-				/**
-				 * Filters the site icon URL for use in the oEmbed template.
-				 *
-				 * @param string $site_icon_url The site icon URL.
-				 */
-				$site_icon_url = apply_filters( 'oembed_site_icon_url', $site_icon_url );
-
-				printf(
-					'<img src="%s" width="32" height="32" alt="" class="wp-embed-site-icon"/>',
-					esc_url( $site_icon_url )
-				);
-				?>
 				<div class="wp-embed-site-title">
-					<?php printf( '<a href="%s" target="_top">%s</a>', esc_url( home_url() ), get_bloginfo( 'name' ) ); ?>
+					<?php
+					$site_icon_url = admin_url( 'images/w-logo-blue.png' );
+
+					if ( function_exists( 'get_site_icon_url' ) ) {
+						$site_icon_url = get_site_icon_url( 32, $site_icon_url );
+					}
+
+					/**
+					 * Filters the site icon URL for use in the oEmbed template.
+					 *
+					 * @param string $site_icon_url The site icon URL.
+					 */
+					$site_icon_url = apply_filters( 'oembed_site_icon_url', $site_icon_url );
+
+					printf(
+						'<a href="%s" target="_top"><img src="%s" width="32" height="32" alt="" class="wp-embed-site-icon"/><span>%s</span></a>',
+						esc_url( home_url() ),
+						esc_url( $site_icon_url ),
+						esc_attr( get_bloginfo( 'name' ) )
+					);
+					?>
 				</div>
 			</div>
 			<div class="wp-embed-social">


### PR DESCRIPTION
This differs from #111 as it removes the unnecessary usage of `position: relative;` etc. and uses a simple `vertical-align` to properly align the site icon. I made sure to have nice link outlines on focus and full RTL support:

<img width="266" alt="screen shot 2015-09-21 at 09 11 47" src="https://cloud.githubusercontent.com/assets/841956/9986871/e9390ea0-6041-11e5-96bd-f24f9f4b43f8.png">
<img width="375" alt="screen shot 2015-09-21 at 09 12 16" src="https://cloud.githubusercontent.com/assets/841956/9986870/e938a122-6041-11e5-8523-87cc34249a28.png">

Not sure about the alignment in the second screenshot. Perhaps the icon should be in the middle of the text, but then it wouldn't be vertically aligned with the social icons anymore.

Fixes #110