### PR TITLE
Don't white-list the current site as an oEmbed provider

### DIFF
--- a/includes/default-filters.php
+++ b/includes/default-filters.php
@@ -13,9 +13,6 @@
 // Load the plugin textdomain.
 add_action( 'init', 'wp_oembed_load_textdomain' );
 
-// Whitelist this site as an oEmbed provider.
-add_action( 'init', 'wp_oembed_add_site_as_provider' );
-
 // Register scripts.
 add_action( 'init', 'wp_oembed_register_scripts' );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -239,13 +239,6 @@ function wp_oembed_load_textdomain() {
 }
 
 /**
- * Add this site to the whitelist of oEmbed providers.
- */
-function wp_oembed_add_site_as_provider() {
-	wp_oembed_add_provider( home_url( '/*' ), get_oembed_endpoint_url() );
-}
-
-/**
  * Register our scripts.
  */
 function wp_oembed_register_scripts() {
@@ -398,11 +391,10 @@ function wp_filter_oembed_result( $html, $url ) {
 	require_once( ABSPATH . WPINC . '/class-oembed.php' );
 	$wp_oembed = _wp_oembed_get_object();
 
-	$trusted = $current_site = false;
+	$trusted = false;
 
 	foreach ( $wp_oembed->providers as $matchmask => $data ) {
-		$regex        = $data[1];
-		$originalmask = $matchmask;
+		$regex = $data[1];
 
 		// Turn the asterisk-type provider URLs into regex.
 		if ( ! $regex ) {
@@ -411,10 +403,6 @@ function wp_filter_oembed_result( $html, $url ) {
 		}
 
 		if ( preg_match( $matchmask, $url ) ) {
-			if ( home_url( '/*' ) === $originalmask ) {
-				$current_site = true;
-			}
-
 			$trusted = true;
 			break;
 		}
@@ -433,7 +421,7 @@ function wp_filter_oembed_result( $html, $url ) {
 		),
 	);
 
-	if ( ! $trusted || $current_site ) {
+	if ( ! $trusted ) {
 		$html = wp_kses( $html, $allowed_html );
 		$html = preg_replace( '|^(<iframe.*?></iframe>).*$|', '$1', $html );
 		$html = str_replace( '<iframe', '<iframe sandbox="allow-scripts" security="restricted"', $html );

--- a/phpunit.multisite.xml
+++ b/phpunit.multisite.xml
@@ -1,0 +1,30 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<php>
+		<const name="WP_TESTS_MULTISITE" value="1"/>
+	</php>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">tests/</directory>
+		</testsuite>
+	</testsuites>
+
+	<filter>
+		<blacklist>
+			<directory suffix=".php">.</directory>
+		</blacklist>
+		<whitelist>
+			<directory suffix=".php">./includes</directory>
+			<file>./wp-api-oembed.php</file>
+			<exclude>
+				<file>./includes/default-filters.php</file>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -38,21 +38,6 @@ class WP_oEmbed_Test_Plugin extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test if the site was added as an oEmbed provider.
-	 */
-	function test_add_oembed_provider() {
-		$oembed = _wp_oembed_get_object();
-
-		wp_oembed_remove_provider( home_url( '/*' ) );
-		$this->assertArrayNotHasKey( home_url( '/*' ), $oembed->providers );
-
-		wp_oembed_add_site_as_provider();
-
-		$this->assertArrayHasKey( home_url( '/*' ), $oembed->providers );
-		$this->assertEquals( array( get_oembed_endpoint_url(), false ), $oembed->providers[ home_url( '/*' ) ] );
-	}
-
-	/**
 	 * Test the get_post_embed_url function.
 	 */
 	function test_get_post_embed_url_non_existent_post() {
@@ -217,7 +202,6 @@ class WP_oEmbed_Test_Plugin extends WP_UnitTestCase {
 
 		// Init.
 		$this->assertarrayHasKey( 'wp_oembed_load_textdomain', $wp_filter['init'][10] );
-		$this->assertarrayHasKey( 'wp_oembed_add_site_as_provider', $wp_filter['init'][10] );
 		$this->assertarrayHasKey( 'wp_oembed_register_scripts', $wp_filter['init'][10] );
 		$this->assertarrayHasKey( 'wp_oembed_rewrite_endpoint', $wp_filter['init'][10] );
 

--- a/tests/test-wp-legacy-oembed-controller.php
+++ b/tests/test-wp-legacy-oembed-controller.php
@@ -218,4 +218,38 @@ class WP_Legacy_oEmbed_Test_Controller extends WP_UnitTestCase {
 
 		$this->assertEquals( 'Not implemented',  $legacy_controller->dispatch( $request ) );
 	}
+
+	/**
+	 * Test request for a child blog post embed in root blog.
+	 *
+	 * @group multisite
+	 */
+	function test_request_ms_child_in_root_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( __METHOD__ . ' is a multisite-only test.' );
+		}
+
+		$child = $this->factory->blog->create();
+
+		switch_to_blog( $child );
+
+		$post = $this->factory->post->create_and_get( array(
+			'post_title'  => 'Hello Child Blog',
+		) );
+
+		$request = array(
+			'url'	   => get_permalink( $post->ID ),
+			'format'   => 'json',
+			'maxwidth' => 600,
+			'callback' => '',
+		);
+
+		$legacy_controller = new WP_Legacy_oEmbed_Controller();
+
+		$data = json_decode( $legacy_controller->dispatch( $request ), true );
+
+		$this->assertTrue( is_array( $data ) );
+
+		restore_current_blog();
+	}
 }


### PR DESCRIPTION
This should resolve some problems with WordPress installs in subdirectories or subdirectory Multisite installs.

See #97