### PR TITLE
Remove the `title` attribute from the response's iframe

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -114,11 +114,10 @@ function get_post_embed_html( $post = null, $width, $height ) {
 	$embed_url = get_post_embed_url( $post );
 
 	$output = sprintf(
-		'<iframe sandbox="allow-scripts" security="restricted" src="%1$s" width="%2$d" height="%3$d" title="%4$s" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>',
+		'<iframe sandbox="allow-scripts" security="restricted" src="%1$s" width="%2$d" height="%3$d" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>',
 		esc_url( $embed_url ),
 		$width,
-		$height,
-		__( 'Embedded WordPress Post', 'oembed-api' )
+		$height
 	);
 
 	/**

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -85,7 +85,7 @@ class WP_oEmbed_Test_Plugin extends WP_UnitTestCase {
 	function test_get_post_embed_html() {
 		$post_id = $this->factory->post->create();
 
-		$expected = '<iframe sandbox="allow-scripts" security="restricted" src="' . esc_url( get_post_embed_url( $post_id ) ) . '" width="200" height="200" title="Embedded WordPress Post" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>';
+		$expected = '<iframe sandbox="allow-scripts" security="restricted" src="' . esc_url( get_post_embed_url( $post_id ) ) . '" width="200" height="200" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>';
 
 		$this->assertEquals( $expected, get_post_embed_html( $post_id, 200, 200 ) );
 	}


### PR DESCRIPTION
The `title` attribute on the sanitised `iframe` element is an odd one. It's not shown as a tooltip in browsers like it normally is.

I don't believe this attribute serves any purpose, but I could be mistaken. Is there a reason for it? If not, let's pull it out.