### PR TITLE
Add a `wp-embedded-content` class to the iframe

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -119,7 +119,7 @@ function get_post_embed_html( $post = null, $width, $height ) {
 	$output .= "\n}\n</script>";
 
 	$output .= sprintf(
-		'<iframe sandbox="allow-scripts" security="restricted" src="%1$s" width="%2$d" height="%3$d" title="%4$s" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>',
+		'<iframe sandbox="allow-scripts" security="restricted" src="%1$s" width="%2$d" height="%3$d" title="%4$s" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" class="wp-embedded-content"></iframe>',
 		esc_url( $embed_url ),
 		$width,
 		$height,
@@ -437,6 +437,7 @@ function wp_filter_oembed_result( $html, $url ) {
 			'marginheight' => true,
 			'scrolling'    => true,
 			'title'        => true,
+			'class'        => true,
 		),
 	);
 

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -85,7 +85,7 @@ class WP_oEmbed_Test_Plugin extends WP_UnitTestCase {
 	function test_get_post_embed_html() {
 		$post_id = $this->factory->post->create();
 
-		$expected = '<iframe sandbox="allow-scripts" security="restricted" src="' . esc_url( get_post_embed_url( $post_id ) ) . '" width="200" height="200" title="Embedded WordPress Post" frameborder="0" marginwidth="0" marginheight="0" scrolling="no"></iframe>';
+		$expected = '<iframe sandbox="allow-scripts" security="restricted" src="' . esc_url( get_post_embed_url( $post_id ) ) . '" width="200" height="200" title="Embedded WordPress Post" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" class="wp-embedded-content"></iframe>';
 
 		$this->assertStringEndsWith( $expected, get_post_embed_html( $post_id, 200, 200 ) );
 	}


### PR DESCRIPTION
Similar to `wp-embedded-audio` and `wp-embedded-video`.

Fixes #119