### PR TITLE
Return oEmbed from trusted providers without check

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -457,7 +457,7 @@ function wp_filter_oembed_result( $html, $url ) {
 		}
 	}
 
-	if ( ! $html || false === strpos( $html, '<iframe' ) ) {
+	if ( ! $html || ( ! $trusted && false === strpos( $html, '<iframe' ) ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Previously, any oEmbed return that lacked an iframe tag was rejected. Twitter and Flickr, at least, does not return iframes.

I'm not familiar with the history of that check being added, so one idea is to allow trusted providers to use whatever html they send back. Untrusted providers would still need an iframe.

Fixes #143