### PR TITLE
Adding more robust handling of existing window.onload function

### DIFF
--- a/scripts/frontend.js
+++ b/scripts/frontend.js
@@ -33,7 +33,11 @@ window.addEventListener( 'message', receiveEmbedMessage, false );
 
 var existingOnload = window.onload;
 window.onload = function () {
-	if ( typeof existingOnload === 'function' ) { existingOnload(); }
+	if ( typeof existingOnload === 'function' ) { 
+		try {
+			existingOnload();
+		} catch(e) {}
+	}
 
 	var isIE10 = 10 === new Function( "/*@cc_on return @_jscript_version; @*/" )(),
 		isIE11 = !! navigator.userAgent.match( /Trident.*rv\:11\./ );


### PR DESCRIPTION
Enclosing the existing window.onload function in try...catch statement will make sure that our function will be executed even if the original one fails, eg. due to errors.

Improves the code fixing #142 