### PR TITLE
Show players for video and audio attachments

### DIFF
--- a/includes/default-filters.php
+++ b/includes/default-filters.php
@@ -74,3 +74,6 @@ add_filter( 'the_excerpt_embed', 'convert_chars' );
 add_filter( 'the_excerpt_embed', 'wpautop' );
 add_filter( 'the_excerpt_embed', 'shortcode_unautop' );
 add_filter( 'the_excerpt_embed', 'wp_oembed_excerpt_attachment' );
+
+add_filter( 'oembed_response_data', 'get_oembed_response_data_author', 10, 2 );
+add_filter( 'oembed_response_data', 'get_oembed_response_data_media', 10, 2 );

--- a/includes/default-filters.php
+++ b/includes/default-filters.php
@@ -16,6 +16,9 @@ add_action( 'init', 'wp_oembed_load_textdomain' );
 // Register scripts.
 add_action( 'init', 'wp_oembed_register_scripts' );
 
+// Disable the admin bar in embeds.
+add_action( 'parse_query', 'wp_oembed_disable_admin_bar' );
+
 // Load fallback if REST API isn't available.
 if ( ! defined( 'REST_API_VERSION' ) || ! version_compare( REST_API_VERSION, '2.0-beta3', '>=' ) ) {
 	// Pull in the required class.
@@ -59,7 +62,6 @@ add_action( 'wp_head', 'wp_print_head_scripts' );
 add_action( 'oembed_head', 'print_emoji_detection_script' );
 add_action( 'oembed_head', 'print_emoji_styles' );
 add_action( 'oembed_head', 'wp_print_head_scripts' );
-add_action( 'oembed_head', 'wp_oembed_dequeue_styles', 1 );
 
 add_action( 'oembed_footer', 'wp_print_footer_scripts', 20 );
 

--- a/includes/default-filters.php
+++ b/includes/default-filters.php
@@ -73,3 +73,4 @@ add_filter( 'the_excerpt_embed', 'wptexturize' );
 add_filter( 'the_excerpt_embed', 'convert_chars' );
 add_filter( 'the_excerpt_embed', 'wpautop' );
 add_filter( 'the_excerpt_embed', 'shortcode_unautop' );
+add_filter( 'the_excerpt_embed', 'wp_oembed_excerpt_attachment' );

--- a/includes/default-filters.php
+++ b/includes/default-filters.php
@@ -54,9 +54,14 @@ add_filter( 'template_redirect', 'wp_oembed_old_slug_redirect', 1 );
 
 add_action( 'wp_head', 'wp_oembed_add_discovery_links' );
 add_action( 'wp_head', 'wp_oembed_add_host_js' );
+add_action( 'wp_head', 'wp_print_head_scripts' );
 
 add_action( 'oembed_head', 'print_emoji_detection_script' );
 add_action( 'oembed_head', 'print_emoji_styles' );
+add_action( 'oembed_head', 'wp_print_head_scripts' );
+add_action( 'oembed_head', 'wp_oembed_dequeue_styles', 1 );
+
+add_action( 'oembed_footer', 'wp_print_footer_scripts', 20 );
 
 add_filter( 'oembed_result', 'wp_filter_oembed_result', 10, 2 );
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -569,3 +569,12 @@ function wp_oembed_old_slug_redirect() {
 	wp_redirect( get_post_embed_url( $post_id ), 301 );
 	exit;
 }
+
+/**
+ * Dequeue all styles and scripts in the embed template by default.
+ */
+function wp_oembed_dequeue_styles() {
+	global $wp_styles, $wp_scripts;
+	$wp_styles->queue = array();
+	$wp_scripts->queue = array();
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -408,8 +408,6 @@ function is_embed() {
 /**
  * If the $url isn't on the trusted providers list, we need to filter the HTML heavily for security.
  *
- * @SuppressWarnings(PHPMD.CyclomaticComplexity)
- *
  * @param string $html The unfiltered oEmbed HTML.
  * @param string $url  URL of the content to be embedded.
  * @return string The filtered and sanitized oEmbed result.
@@ -514,7 +512,7 @@ function the_excerpt_embed() {
  * Shows players for video and audio attachments.
  *
  * @param string $content The current post excerpt.
- * @return THe modified post excerpt.
+ * @return string The modified post excerpt.
  */
 function wp_oembed_excerpt_attachment( $content ) {
 	if ( is_attachment() ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -602,12 +602,10 @@ function wp_oembed_old_slug_redirect() {
 }
 
 /**
- * Dequeue all styles and scripts in the embed template by default.
+ * Disable the admin bar in the embed template.
  */
-function wp_oembed_dequeue_styles() {
-	$wp_styles  = wp_styles();
-	$wp_scripts = wp_scripts();
-
-	$wp_styles->queue  = array();
-	$wp_scripts->queue = array();
+function wp_oembed_disable_admin_bar() {
+	if ( is_embed() ) {
+		add_filter( 'show_admin_bar', '__return_false' );
+	}
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -196,6 +196,10 @@ function get_oembed_response_data( $post = null, $width ) {
 
 	$height = ceil( $width / 16 * 9 );
 
+	if ( 200 > $height ) {
+		$height = 200;
+	}
+
 	$data = array(
 		'version'       => '1.0',
 		'provider_name' => get_bloginfo( 'name' ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -590,7 +590,9 @@ function wp_oembed_old_slug_redirect() {
  * Dequeue all styles and scripts in the embed template by default.
  */
 function wp_oembed_dequeue_styles() {
-	global $wp_styles, $wp_scripts;
-	$wp_styles->queue = array();
+	$wp_styles  = wp_styles();
+	$wp_scripts = wp_scripts();
+
+	$wp_styles->queue  = array();
 	$wp_scripts->queue = array();
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -510,6 +510,22 @@ function the_excerpt_embed() {
 }
 
 /**
+ * Filters the post excerpt for the embed template.
+ *
+ * Shows players for video and audio attachments.
+ *
+ * @param string $content The current post excerpt.
+ * @return THe modified post excerpt.
+ */
+function wp_oembed_excerpt_attachment( $content ) {
+	if ( is_attachment() ) {
+		return prepend_attachment( '' );
+	}
+
+	return $content;
+}
+
+/**
  * Custom old slug redirection function.
  *
  * @SuppressWarnings(PHPMD.CyclomaticComplexity)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -147,22 +147,12 @@ function get_post_embed_html( $post = null, $width, $height ) {
  * @return array|false Response data on success, false if post doesn't exist.
  */
 function get_oembed_response_data( $post = null, $width ) {
-	/**
-	 * Current post object.
-	 *
-	 * @var WP_Post $post
-	 */
 	$post = get_post( $post );
 
 	if ( ! $post ) {
 		return false;
 	}
 
-	/**
-	 * User object for the post author.
-	 *
-	 * @var WP_User $author
-	 */
 	$author = get_userdata( $post->post_author );
 
 	// If a post doesn't have an author, fall back to the site's name.
@@ -220,8 +210,13 @@ function get_oembed_response_data( $post = null, $width ) {
 		$thumbnail_id = get_post_thumbnail_id( $post->ID );
 	}
 
-	if ( 'attachment' === get_post_type( $post ) && wp_attachment_is_image( $post->ID ) ) {
-		$thumbnail_id = $post->ID;
+	if ( 'attachment' === get_post_type( $post ) ) {
+		if ( wp_attachment_is_image( $post ) ) {
+			$thumbnail_id = $post->ID;
+		} else if ( wp_attachment_is( 'video', $post ) ) {
+			$thumbnail_id = get_post_thumbnail_id( $post );
+			$data['type'] = 'video';
+		}
 	}
 
 	if ( $thumbnail_id ) {
@@ -232,7 +227,7 @@ function get_oembed_response_data( $post = null, $width ) {
 	}
 
 	/**
-	 * Filters the oEmbed response data.
+	 * Filter the oEmbed response data.
 	 *
 	 * @param array   $data The response data.
 	 * @param WP_Post $post The post object.

--- a/includes/template.php
+++ b/includes/template.php
@@ -423,8 +423,8 @@
 	do_action( 'oembed_head' );
 	?>
 </head>
-<body>
-<div class="wp-embed">
+<body <?php body_class(); ?>>
+<div <?php post_class( 'wp-embed' ); ?>>
 	<?php
 	if ( have_posts() ) :
 		while ( have_posts() ) : the_post();

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -12,5 +12,6 @@
 		<exclude name="WordPress.XSS.EscapeOutput" />
 		<exclude name="WordPress.VIP.DirectDatabaseQuery" />
 		<exclude name="WordPress.WP.PreparedSQL" />
+		<exclude name="WordPress.VIP.AdminBarRemoval" />
 	</rule>
 </ruleset>

--- a/scripts/frontend.js
+++ b/scripts/frontend.js
@@ -11,8 +11,8 @@
 				var height = e.data.value;
 				if ( height > 1000 ) {
 					height = 1000;
-				} else if ( height < 100 ) {
-					height = 100;
+				} else if ( height < 200 ) {
+					height = 200;
 				}
 
 				source.height = (height) + "px";

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -130,7 +130,7 @@ class WP_oEmbed_Test_Plugin extends WP_UnitTestCase {
 		$data = get_oembed_response_data( $post, 100 );
 
 		$this->assertEquals( 200, $data['width'] );
-		$this->assertEquals( 113, $data['height'] );
+		$this->assertEquals( 200, $data['height'] );
 	}
 
 	function test_get_oembed_response_data_thumbnail() {


### PR DESCRIPTION
This PR adds proper video/audio players for attachments.

Note: The `wp_oembed_dequeue_styles` hack is kinda ugly; improvements welcome.

See #133, #13