### PR TITLE
Use `wp` namespace for the `receiveEmbedMessage` function

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -116,9 +116,8 @@ function get_post_embed_html( $post = null, $width, $height ) {
 	$embed_url = get_post_embed_url( $post );
 
 	$output = "<script type='text/javascript'>\n";
-	$output .= "if ( ! receiveEmbedMessage || typeof( receiveEmbedMessage ) != 'function' ) {\n";
 	$output .= file_get_contents( dirname( dirname( __FILE__ ) ) . '/scripts/frontend.js' );
-	$output .= "\n}\n</script>";
+	$output .= "\n</script>";
 
 	$output .= sprintf(
 		'<iframe sandbox="allow-scripts" security="restricted" src="%1$s" width="%2$d" height="%3$d" title="%4$s" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" class="wp-embedded-content"></iframe>',

--- a/scripts/frontend.js
+++ b/scripts/frontend.js
@@ -1,7 +1,14 @@
 ( function ( window, document ) {
 	'use strict';
 
-	function receiveEmbedMessage( e ) {
+	window.wp = window.wp || {};
+
+	// Don't execute this twice.
+	if ( !! window.wp.receiveEmbedMessage ) {
+		return;
+	}
+
+	window.wp.receiveEmbedMessage = function( e ) {
 		if ( ! ( e.data.secret || e.data.message || e.data.value ) ) {
 			return;
 		}
@@ -35,7 +42,7 @@
 		}
 	}
 
-	window.addEventListener( 'message', receiveEmbedMessage, false );
+	window.addEventListener( 'message', window.wp.receiveEmbedMessage, false );
 
 	function onLoad() {
 		var isIE10 = 10 === new Function( "/*@cc_on return @_jscript_version; @*/" )(),


### PR DESCRIPTION
Moves the check to not execute it twice inside the JS.

Fixes #146